### PR TITLE
Fix axios post credentials

### DIFF
--- a/app/crud/like.py
+++ b/app/crud/like.py
@@ -15,6 +15,8 @@ async def like_stock(
     if existing_like:
         if existing_like.like_type == action:
             await remove_like(stock_id=stock_id, user_id=user_id)
+            return {"message": f"Stock {action} removed"}
+
         else:
             # Update the like_type if the user is changing their action
             existing_like.like_type = action

--- a/app/routes/comment.py
+++ b/app/routes/comment.py
@@ -1,11 +1,12 @@
 from beanie import PydanticObjectId
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, FastAPI, HTTPException
+from pydantic import BaseModel
 
 from app.crud.comment import (
+    dislike_comment,
+    like_comment,
     post_comment,
     post_reply,
-    like_comment,
-    dislike_comment,
     remove_like,
 )
 from app.db import User
@@ -17,13 +18,20 @@ from app.users import current_active_user
 router = APIRouter()
 
 
+# Define a model for the request body
+class CommentIn(BaseModel):
+    content: str
+
+
 @router.post("/stocks/{stock_id}/comment")
 async def create_comment(
     stock_id: PydanticObjectId,
-    content: str,
+    comment_in: CommentIn = Body(...),
     user: User = Depends(current_active_user),
 ):
-    return await post_comment(stock_id=stock_id, user_id=user.id, content=content)
+    return await post_comment(
+        stock_id=stock_id, user_id=user.id, content=comment_in.content
+    )
 
 
 @router.post("/comments/{comment_id}/reply")

--- a/app/routes/stocklike.py
+++ b/app/routes/stocklike.py
@@ -1,5 +1,6 @@
 from beanie import PydanticObjectId
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException
+from pydantic import BaseModel
 
 from app.crud.like import like_stock, remove_like
 from app.db import User
@@ -10,16 +11,16 @@ from app.users import current_active_user
 router = APIRouter()
 
 
-@router.get("/stocks/{stock_id}/like")
-async def like_a_stock(
-    stock_id: PydanticObjectId,
-    action: LikeType = "like",
-    user: User = Depends(current_active_user),
-):
-    try:
-        return await like_stock(stock_id=stock_id, user_id=user.id, action="like")
-    except Exception as e:
-        print("Problem")
+# @router.get("/stocks/{stock_id}/like")
+# async def like_a_stock(
+#     stock_id: PydanticObjectId,
+#     action: LikeType = "like",
+#     user: User = Depends(current_active_user),
+# ):
+#     try:
+#         return await like_stock(stock_id=stock_id, user_id=user.id, action="like")
+#     except Exception as e:
+#         print("Problem")
 
 
 @router.get("/stocks/{stock_id}/dislike")
@@ -29,3 +30,22 @@ async def dislike_a_stock(
     user: User = Depends(current_active_user),
 ):
     return await like_stock(stock_id=stock_id, user_id=user.id, action="dislike")
+
+
+# Define a Pydantic model for the request body
+class LikeIn(BaseModel):
+    action: LikeType
+
+
+@router.post("/stocks/{stock_id}/like")
+async def like_a_stock(
+    stock_id: PydanticObjectId,
+    like_in: LikeIn = Body(...),
+    user: User = Depends(current_active_user),
+):
+    try:
+        return await like_stock(
+            stock_id=stock_id, user_id=user.id, action=like_in.action
+        )
+    except Exception as e:
+        print("Problem")

--- a/app/routes/stocklike.py
+++ b/app/routes/stocklike.py
@@ -23,21 +23,36 @@ router = APIRouter()
 #         print("Problem")
 
 
-@router.get("/stocks/{stock_id}/dislike")
-async def dislike_a_stock(
-    stock_id: PydanticObjectId,
-    action: LikeType,
-    user: User = Depends(current_active_user),
-):
-    return await like_stock(stock_id=stock_id, user_id=user.id, action="dislike")
+# @router.get("/stocks/{stock_id}/dislike")
+# async def dislike_a_stock(
+#     stock_id: PydanticObjectId,
+#     action: LikeType,
+#     user: User = Depends(current_active_user),
+# ):
+#     return await like_stock(stock_id=stock_id, user_id=user.id, action="dislike")
 
 
+# FastApi has a special Body(...) Pydantic model that pulls data from the request body
 # Define a Pydantic model for the request body
 class LikeIn(BaseModel):
     action: LikeType
 
 
 @router.post("/stocks/{stock_id}/like")
+async def like_a_stock(
+    stock_id: PydanticObjectId,
+    like_in: LikeIn = Body(...),
+    user: User = Depends(current_active_user),
+):
+    try:
+        return await like_stock(
+            stock_id=stock_id, user_id=user.id, action=like_in.action
+        )
+    except Exception as e:
+        print("Problem")
+
+
+@router.post("/stocks/{stock_id}/dislike")
 async def like_a_stock(
     stock_id: PydanticObjectId,
     like_in: LikeIn = Body(...),

--- a/frontend/stockranker/public/index.html
+++ b/frontend/stockranker/public/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <title>Stock Ranker</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="initial-scale=1, width=device-width" />
     <div id="root"></div>

--- a/frontend/stockranker/src/components/StockTable.js
+++ b/frontend/stockranker/src/components/StockTable.js
@@ -128,9 +128,11 @@ const StockTable = ({ stocks, onUpdateStock }) => {
 
   const handleDislike = async (stock_id) => {
     await axios
-      .get(`http://localhost:8000/stocks/${stock_id}/dislike?action=dislike`, {
-        withCredentials: true,
-      })
+      .post(
+        `http://localhost:8000/stocks/${stock_id}/dislike`,
+        { action: "dislike" },
+        { withCredentials: true } // here is the correct place for withCredentials
+      )
       .then((response) => {
         axios
           .get(`http://localhost:8000/stocks_with_likes/${stock_id}`, {

--- a/frontend/stockranker/src/components/StockTable.js
+++ b/frontend/stockranker/src/components/StockTable.js
@@ -14,8 +14,8 @@ import ThumbDownIcon from "@mui/icons-material/ThumbDown";
 //import SearchTableHeader from "./SearchTableHeader.js";
 import axios from "axios";
 
-const StockTable = ({stocks, onUpdateStock}) => {
-  const [isEditing, setIsEditing] = useState(false)
+const StockTable = ({ stocks, onUpdateStock }) => {
+  const [isEditing, setIsEditing] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const columns = useMemo(
@@ -32,18 +32,18 @@ const StockTable = ({stocks, onUpdateStock}) => {
       {
         Header: "Price",
         accessor: "price",
-        sortType: 'basic',
+        sortType: "basic",
         Cell: ({ value }) => <span>{`$${value.toFixed(2)}`}</span>,
       },
       {
         Header: "Ticker",
         accessor: "ticker",
-        sortType: 'basic',
+        sortType: "basic",
       },
       {
         Header: "Name",
         accessor: "name",
-        sortType: 'basic',
+        sortType: "basic",
       },
       {
         Header: "Industry",
@@ -90,14 +90,14 @@ const StockTable = ({stocks, onUpdateStock}) => {
     rows,
     prepareRow,
     state,
-    setGlobalFilter
+    setGlobalFilter,
   } = useTable(
     {
       columns,
       data: stocks,
       initialState: {
-        globalFilter: ""
-      }
+        globalFilter: "",
+      },
     },
     useFilters,
     useGlobalFilter,
@@ -108,23 +108,21 @@ const StockTable = ({stocks, onUpdateStock}) => {
 
   const handleLike = async (stock_id) => {
     await axios
-      .get(`http://localhost:8000/stocks/${stock_id}/like?action=like`, {
-        withCredentials: true,
-      })
-      .then(
-        (response) => {
-          axios
-          .get(`http://localhost:8000/stocks_with_likes/${stock_id}`, {
-            withCredentials: true
-          })
-          .then(
-            (response) => {
-              handleStockUpdate(response.data)
-            }
-          )
-          .catch((err) => console.log(err));
-        }
+      .post(
+        `http://localhost:8000/stocks/${stock_id}/like`,
+        { action: "like" },
+        { withCredentials: true } // here is the correct place for withCredentials
       )
+      .then((response) => {
+        axios
+          .get(`http://localhost:8000/stocks_with_likes/${stock_id}`, {
+            withCredentials: true,
+          })
+          .then((response) => {
+            handleStockUpdate(response.data);
+          })
+          .catch((err) => console.log(err));
+      })
       .catch((err) => console.log(err));
   };
 
@@ -133,20 +131,16 @@ const StockTable = ({stocks, onUpdateStock}) => {
       .get(`http://localhost:8000/stocks/${stock_id}/dislike?action=dislike`, {
         withCredentials: true,
       })
-      .then(
-        (response) => {
-          axios
+      .then((response) => {
+        axios
           .get(`http://localhost:8000/stocks_with_likes/${stock_id}`, {
-            withCredentials: true
+            withCredentials: true,
           })
-          .then(
-            (response) => {
-              handleStockUpdate(response.data)
-            }
-          )
+          .then((response) => {
+            handleStockUpdate(response.data);
+          })
           .catch((err) => console.log(err));
-        }
-      )
+      })
       .catch((err) => console.log(err));
   };
 
@@ -159,25 +153,54 @@ const StockTable = ({stocks, onUpdateStock}) => {
     <div>
       {/*<SearchTableHeader value={{searchTable, searchInput}}/>*/}
       <Typography variant="h3">Stocks</Typography>
-      <div style={{width: "100%", display: "flex", flexFlow: "row", justifyContent: "flex-end", marginBottom: "30px"}}>
-        <div style={{marginRight: "10px"}}>
-          <input type="text" onChange={e => setGlobalFilter(e.target.value)} value={globalFilter} name="searchInput" placeholder="asset, name, currency"
-            style={{fontSize: "16px", color: "#000", width: "300px", height: "35px", display: "block", borderRadius: "5px", paddingLeft: "5px"}} />
+      <div
+        style={{
+          width: "100%",
+          display: "flex",
+          flexFlow: "row",
+          justifyContent: "flex-end",
+          marginBottom: "30px",
+        }}
+      >
+        <div style={{ marginRight: "10px" }}>
+          <input
+            type="text"
+            onChange={(e) => setGlobalFilter(e.target.value)}
+            value={globalFilter}
+            name="searchInput"
+            placeholder="asset, name, currency"
+            style={{
+              fontSize: "16px",
+              color: "#000",
+              width: "300px",
+              height: "35px",
+              display: "block",
+              borderRadius: "5px",
+              paddingLeft: "5px",
+            }}
+          />
         </div>
-        <button style={{
-          fontSize: "15px",
-          color: "#fff",
-          width: "87px",
-          height: "35px",
-          display: "block",
-          cursor: "pointer",
-          borderRadius: "5px",
-          backgroundColor: "#222",
-          outline: "var(--colorSearchInput)",
-          marginRight: "50px",
-        }}>Search</button>
+        <button
+          style={{
+            fontSize: "15px",
+            color: "#fff",
+            width: "87px",
+            height: "35px",
+            display: "block",
+            cursor: "pointer",
+            borderRadius: "5px",
+            backgroundColor: "#222",
+            outline: "var(--colorSearchInput)",
+            marginRight: "50px",
+          }}
+        >
+          Search
+        </button>
       </div>
-      <Table {...getTableProps()} style={{ border: "solid 1px black", borderRadius: "15px" }}>
+      <Table
+        {...getTableProps()}
+        style={{ border: "solid 1px black", borderRadius: "15px" }}
+      >
         <TableHead>
           {headerGroups.map((headerGroup) => (
             <TableRow {...headerGroup.getHeaderGroupProps()}>
@@ -189,12 +212,16 @@ const StockTable = ({stocks, onUpdateStock}) => {
                     background: "aliceblue",
                     color: "black",
                     fontWeight: "bold",
-                    cursor: "pointer"
+                    cursor: "pointer",
                   }}
                 >
                   {column.render("Header")}
                   <span>
-                    {column.isSorted ? (column.isSortedDesc ? " 🔽" : " 🔼") : ""}
+                    {column.isSorted
+                      ? column.isSortedDesc
+                        ? " 🔽"
+                        : " 🔼"
+                      : ""}
                   </span>
                 </TableCell>
               ))}
@@ -211,10 +238,10 @@ const StockTable = ({stocks, onUpdateStock}) => {
                     <TableCell
                       {...cell.getCellProps()}
                       style={{
-                      padding: "20px",
+                        padding: "20px",
                         border: "solid 1px gray",
-                        background: (index%2===0) ? "#FFFFFF" : "#f2f2f2",
-                        color: (indexc===2) ? "#4472de" : "#000000",
+                        background: index % 2 === 0 ? "#FFFFFF" : "#f2f2f2",
+                        color: indexc === 2 ? "#4472de" : "#000000",
                       }}
                     >
                       {cell.render("Cell")}


### PR DESCRIPTION
Axios Post requests need to be formatted with the post credentials as the final configuration. So now we can send post data for likes instead of the former get request that was done before. This same method should be used for commenting in future PR's
example of correct usage:
```
const handleDislike = async (stock_id) => {
    await axios
      .post(
        `http://localhost:8000/stocks/${stock_id}/dislike`,
        { action: "dislike" },
        { withCredentials: true } // here is the correct place for withCredentials
      )
```